### PR TITLE
distinguish the host is inner or outer host of K8s cluster

### DIFF
--- a/chaos.go
+++ b/chaos.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"net"
 	"time"
@@ -50,7 +51,7 @@ func (p *PodInfo) IsOverdue() bool {
 
 func (k Kubernetes) chaosDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg, state request.Request, podInfo *PodInfo) (int, error) {
 	if podInfo.Action == ActionError {
-		return dns.RcodeServerFailure, nil
+		return dns.RcodeServerFailure, fmt.Errorf("dns chaos error")
 	}
 
 	// return random IP

--- a/handler.go
+++ b/handler.go
@@ -59,9 +59,6 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 func (k Kubernetes) getRecords(ctx context.Context, state request.Request) ([]dns.RR, []dns.RR, string, error) {
 	qname := state.QName()
 	zone := plugin.Zones(k.Zones).Matches(qname)
-	//if zone == "" {
-	//	return nil, nil, nil
-	//}
 
 	zone = qname[len(qname)-len(zone):] // maintain case of original query
 	state.Zone = zone
@@ -105,24 +102,6 @@ func (k Kubernetes) getRecords(ctx context.Context, state request.Request) ([]dn
 	}
 
 	return records, extra, zone, err
-
-	/*
-		if k.IsNameError(err) {
-
-			if !k.APIConn.HasSynced() {
-				// If we haven't synchronized with the kubernetes cluster, return server failure
-				return plugin.BackendError(ctx, &k, zone, dns.RcodeServerFailure, state, nil, plugin.Options{})
-			}
-			return plugin.BackendError(ctx, &k, zone, dns.RcodeNameError, state, nil, plugin.Options{})
-		}
-		if err != nil {
-			return dns.RcodeServerFailure, err
-		}
-
-		if len(records) == 0 {
-			return plugin.BackendError(ctx, &k, zone, dns.RcodeSuccess, state, nil, plugin.Options{})
-		}
-	*/
 }
 
 // Name implements the Handler interface.

--- a/handler.go
+++ b/handler.go
@@ -13,7 +13,7 @@ import (
 func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
 	state := request.Request{W: w, Req: r}
 	sourceIP := state.IP()
-	log.Infof("k8s ServeDNS, source IP: %s", sourceIP)
+	log.Infof("k8s ServeDNS, source IP: %s, state: %v", sourceIP, state)
 
 	chaosPod, err := k.getChaosPod(sourceIP)
 	if err != nil {


### PR DESCRIPTION
if the host is recorded in k8s_dns_chaos' cache, then we can treat it as an inner host of K8s cluster