### PR TITLE
fix: build coredns action is missing execute permission for coredns binary

### DIFF
--- a/.github/workflows/upload_image.yaml
+++ b/.github/workflows/upload_image.yaml
@@ -33,6 +33,7 @@ jobs:
         run: |
           echo "k8s_dns_chaos:github.com/chaos-mesh/k8s_dns_chaos" >> plugin.cfg
           SWAGGER=1 UI=1 make coredns
+          chmod +x coredns
 
       - name: upload coredns binary
         uses: actions/upload-artifact@v2

--- a/.github/workflows/upload_image.yaml
+++ b/.github/workflows/upload_image.yaml
@@ -32,6 +32,7 @@ jobs:
       - name: Build Chaos CoreDNS
         run: |
           echo "k8s_dns_chaos:github.com/chaos-mesh/k8s_dns_chaos" >> plugin.cfg
+          go mod edit -require github.com/chaos-mesh/k8s_dns_chaos@649fd5298a454eb59b6080fd670e7f7ea1f5b1b4
           SWAGGER=1 UI=1 make coredns
           chmod +x coredns
 

--- a/.github/workflows/upload_image.yaml
+++ b/.github/workflows/upload_image.yaml
@@ -31,8 +31,7 @@ jobs:
       
       - name: Build Chaos CoreDNS
         run: |
-          sed -i '/kubernetes/a\k8s_dns_chaos\:k8s_dns_chaos' plugin.cfg
-          go mod edit -require github.com/chaos-mesh/k8s_dns_chaos@649fd5298a454eb59b6080fd670e7f7ea1f5b1b4
+          echo "k8s_dns_chaos:github.com/chaos-mesh/k8s_dns_chaos" >> plugin.cfg
           SWAGGER=1 UI=1 make coredns
 
       - name: upload coredns binary


### PR DESCRIPTION
This PR will hopefully fix the issue described within issue #20.

By adding the execute permission to the coredns binary, the coredns binary will hopefully be able to run properly.

Also, updated the `plugin.cfg` with the setting that is mentioned here under `Enable with` section:

https://coredns.io/explugins/k8s_dns_chaos/