### PR TITLE
Add support for static domain-to-IP mapping in k8s_dns_server for DNSChaos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ protoc: ## Generate the protobuf code
 	go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 	protoc --proto_path=pb --go_out=pb --go_opt=paths=source_relative ./pb/dns.proto
 
+fmt:
+	find . -type f -name '*.go' -not -path './pb/**' -exec goimports -w -l {} +
+
 # The help will print out all targets with their descriptions organized bellow their categories. The categories are represented by `##@` and the target descriptions by `##`.
 # The awk commands is responsible to read the entire set of makefiles included in this invocation, looking for lines of the file as xyz: ## something, and then pretty-format the target and help. Then, if there's a line with ##@ something, that gets pretty-printed as a category.
 # More info over the usage of ANSI control characters for terminal formatting: https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/miekg/dns v1.1.43
 	github.com/pingcap/tidb-tools v6.3.0+incompatible
 	github.com/prometheus/client_golang v1.11.0
-	golang.org/x/net v0.0.0-20210614182718-04defd469f4e
 	google.golang.org/grpc v1.41.0
 	k8s.io/api v0.22.2
 	k8s.io/apimachinery v0.22.2
@@ -45,6 +44,7 @@ require (
 	github.com/prometheus/common v0.31.1 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect
 	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
 	golang.org/x/sys v0.0.0-20210917161153-d61c044b1678 // indirect
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect

--- a/grpc_server.go
+++ b/grpc_server.go
@@ -110,10 +110,10 @@ func (k Kubernetes) SetDNSChaos(ctx context.Context, req *pb.SetDNSChaosRequest)
 		k.ipPodMap[v1Pod.Status.PodIP] = podInfo
 		domainIPMap := saveDomainAndIp(req.IpDomainMaps)
 		if domainIPMap != nil {
-			if _, ok := k.domainAndIPMap[pod.Namespace]; !ok {
-				k.domainAndIPMap[pod.Namespace] = make(map[string]map[string]string)
+			if _, ok := k.domainIPMapByNamespacedName[pod.Namespace]; !ok {
+				k.domainIPMapByNamespacedName[pod.Namespace] = make(map[string]map[string]string)
 			}
-			k.domainAndIPMap[pod.Namespace][pod.Name] = domainIPMap
+			k.domainIPMapByNamespacedName[pod.Namespace][pod.Name] = domainIPMap
 		}
 
 	}
@@ -140,8 +140,8 @@ func (k Kubernetes) CancelDNSChaos(ctx context.Context, req *pb.CancelDNSChaosRe
 				delete(k.podMap[pod.Namespace], pod.Name)
 				delete(k.ipPodMap, podInfo.IP)
 			}
-			if _, ok1 := k.domainAndIPMap[pod.Namespace][pod.Name]; ok1 {
-				delete(k.domainAndIPMap[pod.Namespace], pod.Name)
+			if _, ok1 := k.domainIPMapByNamespacedName[pod.Namespace][pod.Name]; ok1 {
+				delete(k.domainIPMapByNamespacedName[pod.Namespace], pod.Name)
 			}
 		}
 	}
@@ -154,7 +154,7 @@ func (k Kubernetes) CancelDNSChaos(ctx context.Context, req *pb.CancelDNSChaosRe
 	}
 	for _, namespace := range shouldDeleteNs {
 		delete(k.podMap, namespace)
-		delete(k.domainAndIPMap, namespace)
+		delete(k.domainIPMapByNamespacedName, namespace)
 	}
 
 	delete(k.chaosMap, req.Name)

--- a/handler.go
+++ b/handler.go
@@ -28,7 +28,7 @@ func (k Kubernetes) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.M
 	if k.needChaos(chaosPod, records, state.QName()) && chaosPod.Action == ActionStatic {
 		log.Debugf("need chaos, but action is static")
 		// Get the domain-IP mapping for the specific namespace and pod name.
-		domainMap := k.domainAndIPMap[chaosPod.Namespace][chaosPod.Name]
+		domainMap := k.domainIPMapByNamespacedName[chaosPod.Namespace][chaosPod.Name]
 		// Check if the domain-IP mapping exists.
 		if domainMap != nil {
 			// Check if the requested domain exists in the mapping.

--- a/handler.go
+++ b/handler.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/request"
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -41,41 +41,41 @@ var dnsTestCases = []test.Case{
 	},
 	{
 		Qname: "svc1.testns.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeSuccess,
+		Rcode:  dns.RcodeSuccess,
 		Answer: []dns.RR{test.SRV("svc1.testns.svc.cluster.local.	5	IN	SRV	0 100 80 svc1.testns.svc.cluster.local.")},
-		Extra: []dns.RR{test.A("svc1.testns.svc.cluster.local.  5       IN      A       10.0.0.1")},
+		Extra:  []dns.RR{test.A("svc1.testns.svc.cluster.local.  5       IN      A       10.0.0.1")},
 	},
 	{
 		Qname: "svcempty.testns.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeSuccess,
+		Rcode:  dns.RcodeSuccess,
 		Answer: []dns.RR{test.SRV("svcempty.testns.svc.cluster.local.	5	IN	SRV	0 100 80 svcempty.testns.svc.cluster.local.")},
-		Extra: []dns.RR{test.A("svcempty.testns.svc.cluster.local.  5       IN      A       10.0.0.1")},
+		Extra:  []dns.RR{test.A("svcempty.testns.svc.cluster.local.  5       IN      A       10.0.0.1")},
 	},
 	{
 		Qname: "svc6.testns.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeSuccess,
+		Rcode:  dns.RcodeSuccess,
 		Answer: []dns.RR{test.SRV("svc6.testns.svc.cluster.local.	5	IN	SRV	0 100 80 svc6.testns.svc.cluster.local.")},
-		Extra: []dns.RR{test.AAAA("svc6.testns.svc.cluster.local.  5       IN      AAAA       1234:abcd::1")},
+		Extra:  []dns.RR{test.AAAA("svc6.testns.svc.cluster.local.  5       IN      AAAA       1234:abcd::1")},
 	},
 	// SRV Service (wildcard)
 	{
 		Qname: "svc1.*.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeSuccess,
+		Rcode:  dns.RcodeSuccess,
 		Answer: []dns.RR{test.SRV("svc1.*.svc.cluster.local.	5	IN	SRV	0 100 80 svc1.testns.svc.cluster.local.")},
-		Extra: []dns.RR{test.A("svc1.testns.svc.cluster.local.  5       IN      A       10.0.0.1")},
+		Extra:  []dns.RR{test.A("svc1.testns.svc.cluster.local.  5       IN      A       10.0.0.1")},
 	},
 	{
 		Qname: "svcempty.*.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeSuccess,
+		Rcode:  dns.RcodeSuccess,
 		Answer: []dns.RR{test.SRV("svcempty.*.svc.cluster.local.	5	IN	SRV	0 100 80 svcempty.testns.svc.cluster.local.")},
-		Extra: []dns.RR{test.A("svcempty.testns.svc.cluster.local.  5       IN      A       10.0.0.1")},
+		Extra:  []dns.RR{test.A("svcempty.testns.svc.cluster.local.  5       IN      A       10.0.0.1")},
 	},
 	// SRV Service (wildcards)
 	{
 		Qname: "*.any.svc1.*.svc.cluster.local.", Qtype: dns.TypeSRV,
-		Rcode: dns.RcodeSuccess,
+		Rcode:  dns.RcodeSuccess,
 		Answer: []dns.RR{test.SRV("*.any.svc1.*.svc.cluster.local.	5	IN	SRV	0 100 80 svc1.testns.svc.cluster.local.")},
-		Extra: []dns.RR{test.A("svc1.testns.svc.cluster.local.  5       IN      A       10.0.0.1")},
+		Extra:  []dns.RR{test.A("svc1.testns.svc.cluster.local.  5       IN      A       10.0.0.1")},
 	},
 	// A Service (wildcards)
 	{
@@ -207,7 +207,7 @@ var dnsTestCases = []test.Case{
 	// AAAA
 	{
 		Qname: "5678-abcd--2.hdls1.testns.svc.cluster.local", Qtype: dns.TypeAAAA,
-		Rcode: dns.RcodeSuccess,
+		Rcode:  dns.RcodeSuccess,
 		Answer: []dns.RR{test.AAAA("5678-abcd--2.hdls1.testns.svc.cluster.local.	5	IN	AAAA	5678:abcd::2")},
 	},
 	// CNAME External

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -69,7 +69,7 @@ type Kubernetes struct {
 
 	ipPodMap map[string]*PodInfo
 
-	domainAndIPMap map[string]map[string]map[string]string
+	domainIPMapByNamespacedName map[string]map[string]map[string]string
 }
 
 // New returns a initialized Kubernetes. It default interfaceAddrFunc to return 127.0.0.1. All other
@@ -83,7 +83,7 @@ func New(zones []string) *Kubernetes {
 	k.chaosMap = make(map[string]*pb.SetDNSChaosRequest)
 	k.podMap = make(map[string]map[string]*PodInfo)
 	k.ipPodMap = make(map[string]*PodInfo)
-	k.domainAndIPMap = make(map[string]map[string]map[string]string)
+	k.domainIPMapByNamespacedName = make(map[string]map[string]map[string]string)
 	rand.Seed(time.Now().UnixNano())
 
 	return k

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/chaos-mesh/k8s_dns_chaos/pb"
 	"math/rand"
 	"net"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/chaos-mesh/k8s_dns_chaos/pb"
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/etcd/msg"
 	"github.com/coredns/coredns/plugin/kubernetes/object"
@@ -68,6 +68,8 @@ type Kubernetes struct {
 	podMap map[string]map[string]*PodInfo
 
 	ipPodMap map[string]*PodInfo
+
+	domainAndIPMap map[string]map[string]map[string]string
 }
 
 // New returns a initialized Kubernetes. It default interfaceAddrFunc to return 127.0.0.1. All other
@@ -81,6 +83,7 @@ func New(zones []string) *Kubernetes {
 	k.chaosMap = make(map[string]*pb.SetDNSChaosRequest)
 	k.podMap = make(map[string]map[string]*PodInfo)
 	k.ipPodMap = make(map[string]*PodInfo)
+	k.domainAndIPMap = make(map[string]map[string]map[string]string)
 	rand.Seed(time.Now().UnixNano())
 
 	return k

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -5,12 +5,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/chaos-mesh/k8s_dns_chaos/pb"
 	"math/rand"
 	"net"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/chaos-mesh/k8s_dns_chaos/pb"
 
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/etcd/msg"

--- a/pb/dns.pb.go
+++ b/pb/dns.pb.go
@@ -4,15 +4,13 @@
 package pb
 
 import (
+	context "context"
 	fmt "fmt"
-
 	proto "github.com/golang/protobuf/proto"
-
-	math "math"
-
-	context "golang.org/x/net/context"
-
 	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
+	math "math"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -24,41 +22,45 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
 type SetDNSChaosRequest struct {
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	Pods []*Pod `protobuf:"bytes,2,rep,name=pods,proto3" json:"pods,omitempty"`
 	// action means the chaos action, values can be "random" or "error"
-	//   "random": return random IP for DNS request
-	//   "error":  return error for DNS request
+	//
+	//	"random": return random IP for DNS request
+	//	"error":  return error for DNS request
 	Action string `protobuf:"bytes,3,opt,name=action,proto3" json:"action,omitempty"`
 	// scope means the chaos scope, values can be "inner", "outer" or "all":
-	//   "inner": chaos only works on the inner host in Kubernetes cluster
-	//   "outer": chaos only works on the outer host of Kubernetes cluster
-	//   "all":   chaos works on all host
-	Scope                string   `protobuf:"bytes,4,opt,name=scope,proto3" json:"scope,omitempty"`
-	Selector             string   `protobuf:"bytes,5,opt,name=selector,proto3" json:"selector,omitempty"`
-	Patterns             []string `protobuf:"bytes,6,rep,name=patterns,proto3" json:"patterns,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	//
+	//	"inner": chaos only works on the inner host in Kubernetes cluster
+	//	"outer": chaos only works on the outer host of Kubernetes cluster
+	//	"all":   chaos works on all host
+	Scope                string         `protobuf:"bytes,4,opt,name=scope,proto3" json:"scope,omitempty"`
+	Selector             string         `protobuf:"bytes,5,opt,name=selector,proto3" json:"selector,omitempty"`
+	Patterns             []string       `protobuf:"bytes,6,rep,name=patterns,proto3" json:"patterns,omitempty"`
+	IpDomainMaps         []*IpDomainMap `protobuf:"bytes,7,rep,name=ipDomainMaps,proto3" json:"ipDomainMaps,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
+	XXX_unrecognized     []byte         `json:"-"`
+	XXX_sizecache        int32          `json:"-"`
 }
 
 func (m *SetDNSChaosRequest) Reset()         { *m = SetDNSChaosRequest{} }
 func (m *SetDNSChaosRequest) String() string { return proto.CompactTextString(m) }
 func (*SetDNSChaosRequest) ProtoMessage()    {}
 func (*SetDNSChaosRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_dns_ad842bfaa9b8d3cd, []int{0}
+	return fileDescriptor_638ff8d8aaf3d8ae, []int{0}
 }
+
 func (m *SetDNSChaosRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SetDNSChaosRequest.Unmarshal(m, b)
 }
 func (m *SetDNSChaosRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_SetDNSChaosRequest.Marshal(b, m, deterministic)
 }
-func (dst *SetDNSChaosRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_SetDNSChaosRequest.Merge(dst, src)
+func (m *SetDNSChaosRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SetDNSChaosRequest.Merge(m, src)
 }
 func (m *SetDNSChaosRequest) XXX_Size() int {
 	return xxx_messageInfo_SetDNSChaosRequest.Size(m)
@@ -111,6 +113,13 @@ func (m *SetDNSChaosRequest) GetPatterns() []string {
 	return nil
 }
 
+func (m *SetDNSChaosRequest) GetIpDomainMaps() []*IpDomainMap {
+	if m != nil {
+		return m.IpDomainMaps
+	}
+	return nil
+}
+
 type Pod struct {
 	Namespace            string   `protobuf:"bytes,1,opt,name=namespace,proto3" json:"namespace,omitempty"`
 	Name                 string   `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
@@ -123,16 +132,17 @@ func (m *Pod) Reset()         { *m = Pod{} }
 func (m *Pod) String() string { return proto.CompactTextString(m) }
 func (*Pod) ProtoMessage()    {}
 func (*Pod) Descriptor() ([]byte, []int) {
-	return fileDescriptor_dns_ad842bfaa9b8d3cd, []int{1}
+	return fileDescriptor_638ff8d8aaf3d8ae, []int{1}
 }
+
 func (m *Pod) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Pod.Unmarshal(m, b)
 }
 func (m *Pod) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_Pod.Marshal(b, m, deterministic)
 }
-func (dst *Pod) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Pod.Merge(dst, src)
+func (m *Pod) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Pod.Merge(m, src)
 }
 func (m *Pod) XXX_Size() int {
 	return xxx_messageInfo_Pod.Size(m)
@@ -168,16 +178,17 @@ func (m *CancelDNSChaosRequest) Reset()         { *m = CancelDNSChaosRequest{} }
 func (m *CancelDNSChaosRequest) String() string { return proto.CompactTextString(m) }
 func (*CancelDNSChaosRequest) ProtoMessage()    {}
 func (*CancelDNSChaosRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_dns_ad842bfaa9b8d3cd, []int{2}
+	return fileDescriptor_638ff8d8aaf3d8ae, []int{2}
 }
+
 func (m *CancelDNSChaosRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CancelDNSChaosRequest.Unmarshal(m, b)
 }
 func (m *CancelDNSChaosRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_CancelDNSChaosRequest.Marshal(b, m, deterministic)
 }
-func (dst *CancelDNSChaosRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CancelDNSChaosRequest.Merge(dst, src)
+func (m *CancelDNSChaosRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CancelDNSChaosRequest.Merge(m, src)
 }
 func (m *CancelDNSChaosRequest) XXX_Size() int {
 	return xxx_messageInfo_CancelDNSChaosRequest.Size(m)
@@ -207,16 +218,17 @@ func (m *DNSChaosResponse) Reset()         { *m = DNSChaosResponse{} }
 func (m *DNSChaosResponse) String() string { return proto.CompactTextString(m) }
 func (*DNSChaosResponse) ProtoMessage()    {}
 func (*DNSChaosResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_dns_ad842bfaa9b8d3cd, []int{3}
+	return fileDescriptor_638ff8d8aaf3d8ae, []int{3}
 }
+
 func (m *DNSChaosResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_DNSChaosResponse.Unmarshal(m, b)
 }
 func (m *DNSChaosResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	return xxx_messageInfo_DNSChaosResponse.Marshal(b, m, deterministic)
 }
-func (dst *DNSChaosResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DNSChaosResponse.Merge(dst, src)
+func (m *DNSChaosResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DNSChaosResponse.Merge(m, src)
 }
 func (m *DNSChaosResponse) XXX_Size() int {
 	return xxx_messageInfo_DNSChaosResponse.Size(m)
@@ -241,11 +253,88 @@ func (m *DNSChaosResponse) GetMsg() string {
 	return ""
 }
 
+// 定义ip 域名的映射关系
+type IpDomainMap struct {
+	Ip                   string   `protobuf:"bytes,1,opt,name=ip,proto3" json:"ip,omitempty"`
+	Domain               string   `protobuf:"bytes,2,opt,name=domain,proto3" json:"domain,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *IpDomainMap) Reset()         { *m = IpDomainMap{} }
+func (m *IpDomainMap) String() string { return proto.CompactTextString(m) }
+func (*IpDomainMap) ProtoMessage()    {}
+func (*IpDomainMap) Descriptor() ([]byte, []int) {
+	return fileDescriptor_638ff8d8aaf3d8ae, []int{4}
+}
+
+func (m *IpDomainMap) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_IpDomainMap.Unmarshal(m, b)
+}
+func (m *IpDomainMap) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_IpDomainMap.Marshal(b, m, deterministic)
+}
+func (m *IpDomainMap) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_IpDomainMap.Merge(m, src)
+}
+func (m *IpDomainMap) XXX_Size() int {
+	return xxx_messageInfo_IpDomainMap.Size(m)
+}
+func (m *IpDomainMap) XXX_DiscardUnknown() {
+	xxx_messageInfo_IpDomainMap.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_IpDomainMap proto.InternalMessageInfo
+
+func (m *IpDomainMap) GetIp() string {
+	if m != nil {
+		return m.Ip
+	}
+	return ""
+}
+
+func (m *IpDomainMap) GetDomain() string {
+	if m != nil {
+		return m.Domain
+	}
+	return ""
+}
+
 func init() {
 	proto.RegisterType((*SetDNSChaosRequest)(nil), "pb.SetDNSChaosRequest")
 	proto.RegisterType((*Pod)(nil), "pb.Pod")
 	proto.RegisterType((*CancelDNSChaosRequest)(nil), "pb.CancelDNSChaosRequest")
 	proto.RegisterType((*DNSChaosResponse)(nil), "pb.DNSChaosResponse")
+	proto.RegisterType((*IpDomainMap)(nil), "pb.IpDomainMap")
+}
+
+func init() { proto.RegisterFile("dns.proto", fileDescriptor_638ff8d8aaf3d8ae) }
+
+var fileDescriptor_638ff8d8aaf3d8ae = []byte{
+	// 340 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x52, 0x4d, 0x4f, 0xf2, 0x40,
+	0x10, 0x7e, 0xfb, 0x41, 0x81, 0xe1, 0x0d, 0x92, 0x09, 0x92, 0x8a, 0x1e, 0x48, 0x4f, 0x24, 0x26,
+	0x35, 0x81, 0x18, 0x2f, 0x7a, 0x11, 0x2e, 0x1e, 0x24, 0xa4, 0xdc, 0xbc, 0x6d, 0xdb, 0x8d, 0x36,
+	0x81, 0xdd, 0xb5, 0xb3, 0xfc, 0x08, 0xff, 0xa5, 0x3f, 0xc5, 0xec, 0x5a, 0x28, 0xf8, 0x91, 0x78,
+	0xdb, 0xe7, 0x63, 0xa6, 0xf3, 0xcc, 0x14, 0xda, 0xb9, 0xa0, 0x58, 0x95, 0x52, 0x4b, 0x74, 0x55,
+	0x1a, 0xbd, 0x3b, 0x80, 0x2b, 0xae, 0xe7, 0x8b, 0xd5, 0xec, 0x85, 0x49, 0x4a, 0xf8, 0xeb, 0x96,
+	0x93, 0x46, 0x04, 0x5f, 0xb0, 0x0d, 0x0f, 0x9d, 0x91, 0x33, 0x6e, 0x27, 0xf6, 0x8d, 0xe7, 0xe0,
+	0x2b, 0x99, 0x53, 0xe8, 0x8e, 0xbc, 0x71, 0x67, 0xd2, 0x8c, 0x55, 0x1a, 0x2f, 0x65, 0x9e, 0x58,
+	0x12, 0x07, 0x10, 0xb0, 0x4c, 0x17, 0x52, 0x84, 0x9e, 0x2d, 0xa9, 0x10, 0xf6, 0xa1, 0x41, 0x99,
+	0x54, 0x3c, 0xf4, 0x2d, 0xfd, 0x09, 0x70, 0x08, 0x2d, 0xe2, 0x6b, 0x9e, 0x69, 0x59, 0x86, 0x0d,
+	0x2b, 0xec, 0xb1, 0xd1, 0x14, 0xd3, 0x9a, 0x97, 0x82, 0xc2, 0x60, 0xe4, 0x19, 0x6d, 0x87, 0x71,
+	0x0a, 0xff, 0x0b, 0x35, 0x97, 0x1b, 0x56, 0x88, 0x47, 0xa6, 0x28, 0x6c, 0xda, 0x51, 0x4e, 0xcc,
+	0x28, 0x0f, 0x35, 0x9f, 0x1c, 0x99, 0xa2, 0x1b, 0xf0, 0x96, 0x32, 0xc7, 0x0b, 0x68, 0x9b, 0x18,
+	0xa4, 0x58, 0xb6, 0xcb, 0x55, 0x13, 0xfb, 0xc0, 0x6e, 0x1d, 0x38, 0xba, 0x84, 0xd3, 0x19, 0x13,
+	0x19, 0x5f, 0xff, 0x61, 0x3b, 0xd1, 0x2d, 0xf4, 0x6a, 0x1b, 0x29, 0x29, 0x88, 0x9b, 0xa5, 0x94,
+	0x9c, 0xb6, 0x6b, 0x6d, 0x9d, 0xad, 0xa4, 0x42, 0xd8, 0x03, 0x6f, 0x43, 0xcf, 0xd5, 0xb7, 0xcc,
+	0x33, 0xba, 0x86, 0xce, 0x41, 0x00, 0xec, 0x82, 0x5b, 0xa8, 0xaa, 0xbd, 0x5b, 0x28, 0xd3, 0x28,
+	0xb7, 0x62, 0x55, 0x53, 0xa1, 0xc9, 0x9b, 0x03, 0xde, 0x7c, 0xb1, 0xc2, 0x3b, 0xe8, 0x1c, 0x1c,
+	0x11, 0x07, 0x66, 0x21, 0xdf, 0xaf, 0x3a, 0xec, 0x1b, 0xfe, 0xeb, 0x94, 0xd1, 0x3f, 0x9c, 0x41,
+	0xf7, 0x38, 0x28, 0x9e, 0x19, 0xe7, 0x8f, 0xe1, 0x7f, 0x6b, 0x72, 0x1f, 0x3c, 0xf9, 0xf1, 0x95,
+	0x4a, 0xd3, 0xc0, 0xfe, 0x5c, 0xd3, 0x8f, 0x00, 0x00, 0x00, 0xff, 0xff, 0xdd, 0x7e, 0x99, 0x58,
+	0x69, 0x02, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -294,6 +383,17 @@ func (c *dNSClient) CancelDNSChaos(ctx context.Context, in *CancelDNSChaosReques
 type DNSServer interface {
 	SetDNSChaos(context.Context, *SetDNSChaosRequest) (*DNSChaosResponse, error)
 	CancelDNSChaos(context.Context, *CancelDNSChaosRequest) (*DNSChaosResponse, error)
+}
+
+// UnimplementedDNSServer can be embedded to have forward compatible implementations.
+type UnimplementedDNSServer struct {
+}
+
+func (*UnimplementedDNSServer) SetDNSChaos(ctx context.Context, req *SetDNSChaosRequest) (*DNSChaosResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SetDNSChaos not implemented")
+}
+func (*UnimplementedDNSServer) CancelDNSChaos(ctx context.Context, req *CancelDNSChaosRequest) (*DNSChaosResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CancelDNSChaos not implemented")
 }
 
 func RegisterDNSServer(s *grpc.Server, srv DNSServer) {
@@ -351,28 +451,4 @@ var _DNS_serviceDesc = grpc.ServiceDesc{
 	},
 	Streams:  []grpc.StreamDesc{},
 	Metadata: "dns.proto",
-}
-
-func init() { proto.RegisterFile("dns.proto", fileDescriptor_dns_ad842bfaa9b8d3cd) }
-
-var fileDescriptor_dns_ad842bfaa9b8d3cd = []byte{
-	// 285 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x51, 0xcd, 0x4e, 0xf3, 0x30,
-	0x10, 0xfc, 0x52, 0xa7, 0xf9, 0x9a, 0xad, 0x84, 0xaa, 0x55, 0xa9, 0x4c, 0xe1, 0x10, 0xe5, 0x54,
-	0x09, 0x29, 0x87, 0x72, 0xe0, 0x02, 0xa7, 0xf4, 0x5c, 0x55, 0xc9, 0x13, 0x38, 0x89, 0x05, 0x48,
-	0xa9, 0x6d, 0xb2, 0xee, 0x43, 0xf0, 0x2c, 0xbc, 0x24, 0xb2, 0x49, 0x1b, 0x7e, 0x25, 0x6e, 0x3b,
-	0xb3, 0x93, 0xec, 0xcc, 0x18, 0xe2, 0x46, 0x51, 0x66, 0x3a, 0x6d, 0x35, 0x8e, 0x4c, 0x95, 0xbe,
-	0x06, 0x80, 0xa5, 0xb4, 0x9b, 0x6d, 0x99, 0x3f, 0x0a, 0x4d, 0x85, 0x7c, 0x3e, 0x48, 0xb2, 0x88,
-	0x10, 0x2a, 0xb1, 0x97, 0x3c, 0x48, 0x82, 0x55, 0x5c, 0xf8, 0x19, 0x2f, 0x21, 0x34, 0xba, 0x21,
-	0x3e, 0x4a, 0xd8, 0x6a, 0xba, 0xfe, 0x9f, 0x99, 0x2a, 0xdb, 0xe9, 0xa6, 0xf0, 0x24, 0x2e, 0x20,
-	0x12, 0xb5, 0x7d, 0xd2, 0x8a, 0x33, 0xff, 0x49, 0x8f, 0x70, 0x0e, 0x63, 0xaa, 0xb5, 0x91, 0x3c,
-	0xf4, 0xf4, 0x3b, 0xc0, 0x25, 0x4c, 0x48, 0xb6, 0xb2, 0xb6, 0xba, 0xe3, 0x63, 0xbf, 0x38, 0x61,
-	0xb7, 0x33, 0xc2, 0x5a, 0xd9, 0x29, 0xe2, 0x51, 0xc2, 0xdc, 0xee, 0x88, 0xd3, 0x5b, 0x60, 0x3b,
-	0xdd, 0xe0, 0x15, 0xc4, 0xce, 0x11, 0x19, 0x51, 0x1f, 0x2d, 0x0e, 0xc4, 0xc9, 0xfb, 0x68, 0xf0,
-	0x9e, 0x5e, 0xc3, 0x79, 0x2e, 0x54, 0x2d, 0xdb, 0x3f, 0x04, 0x4d, 0xef, 0x60, 0x36, 0xc8, 0xc8,
-	0x68, 0x45, 0xd2, 0xe5, 0xeb, 0x24, 0x1d, 0x5a, 0xeb, 0x95, 0x93, 0xa2, 0x47, 0x38, 0x03, 0xb6,
-	0xa7, 0x87, 0xfe, 0x96, 0x1b, 0xd7, 0x2f, 0x01, 0xb0, 0xcd, 0xb6, 0xc4, 0x7b, 0x98, 0x7e, 0x28,
-	0x16, 0x17, 0xae, 0xaf, 0xef, 0x4d, 0x2f, 0xe7, 0x8e, 0xff, 0x7a, 0x2e, 0xfd, 0x87, 0x39, 0x9c,
-	0x7d, 0x76, 0x8c, 0x17, 0x4e, 0xf9, 0x63, 0x8a, 0xdf, 0x7e, 0x52, 0x45, 0xfe, 0xa1, 0x6f, 0xde,
-	0x02, 0x00, 0x00, 0xff, 0xff, 0x6d, 0x16, 0x0c, 0xd6, 0xf5, 0x01, 0x00, 0x00,
 }

--- a/pb/dns.proto
+++ b/pb/dns.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 
 package pb;
-
+option go_package = "./pb";
 service DNS {
   rpc SetDNSChaos(SetDNSChaosRequest) returns (DNSChaosResponse) {}
   rpc CancelDNSChaos(CancelDNSChaosRequest) returns (DNSChaosResponse) {}
@@ -23,6 +23,7 @@ message SetDNSChaosRequest {
   string scope = 4;
   string selector = 5;
   repeated string patterns = 6;
+  repeated IpDomainMap ipDomainMaps = 7;
 }
 
 message Pod {
@@ -37,4 +38,10 @@ message CancelDNSChaosRequest {
 message DNSChaosResponse {
   bool result = 1;
   string msg = 2;
+}
+
+//定义ip 域名的映射关系
+message IpDomainMap {
+  string ip = 1;
+  string domain = 2;
 }

--- a/pb/dns.proto
+++ b/pb/dns.proto
@@ -40,7 +40,8 @@ message DNSChaosResponse {
   string msg = 2;
 }
 
-//定义ip 域名的映射关系
+// Defines the mapping relationship between an IP address and a domain name.
+// This structure represents a single IP-to-domain pair.
 message IpDomainMap {
   string ip = 1;
   string domain = 2;

--- a/setup.go
+++ b/setup.go
@@ -19,9 +19,8 @@ import (
 	"github.com/caddyserver/caddy"
 	"github.com/miekg/dns"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"       // pull this in here, because we want it excluded if plugin.cfg doesn't have k8s
-	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"      // pull this in here, because we want it excluded if plugin.cfg doesn't have k8s
-	_ "k8s.io/client-go/plugin/pkg/client/auth/openstack" // pull this in here, because we want it excluded if plugin.cfg doesn't have k8s
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"  // pull this in here, because we want it excluded if plugin.cfg doesn't have k8s
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc" // pull this in here, because we want it excluded if plugin.cfg doesn't have k8s
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog"
 )


### PR DESCRIPTION
- Backend parses the input into a JSON object {"domain": "google.com", "ip": "1.2.3.4"}.
- The parsed mapping is sent to k8s_dns_server for storage and DNS fault injection.
- For a given domain, the corresponding IP is returned based on the static mapping.
- This change allows static IP resolution for specified domains during fault injection.

- [x] manual testing
<img width="1157" alt="image" src="https://github.com/user-attachments/assets/14be75ff-d5c6-4133-b1ed-446a21ff8ea7" />
<img width="583" alt="image" src="https://github.com/user-attachments/assets/87e48244-ba15-4fbe-a522-36746ec8a95a" />
<img width="578" alt="image" src="https://github.com/user-attachments/assets/301b48d4-e09b-4d11-ad53-53e6051da9a1" />

- [x] regression testing
<img width="1147" alt="image" src="https://github.com/user-attachments/assets/85b6bc98-1460-4d1c-8a13-039b54181c7c" />
<img width="556" alt="image" src="https://github.com/user-attachments/assets/f694be4f-998b-456b-bc60-a8e19e4a4dc4" />

![image](https://github.com/user-attachments/assets/7962ab97-77d7-4f5c-9c9e-f8b6bb29c899)
![image](https://github.com/user-attachments/assets/ab966a1f-786e-4a43-a2cd-236e4dbdd98a)
